### PR TITLE
Fix disappearing checkbox

### DIFF
--- a/view/frontend/templates/magewire/create-account.phtml
+++ b/view/frontend/templates/magewire/create-account.phtml
@@ -12,7 +12,7 @@ if (!$guestCheckerViewModel->isCustomerGuest()) {
 }
 
 ?>
-<div wire:model="accountExists">
+<div>
     <?php if (!$magewire->accountExists): ?>
         <div class="flex gap-x-4">
             <div class="flex items-center">


### PR DESCRIPTION
When the wrapping `div` was wired to `accountExists`, `accountExists` was set to `true` as soon as the checkbox was checked. It then disappeared, as is it only shown, when `accountExists` is `false`.